### PR TITLE
fix(domain): corregir herencia en entidades con kw_only y agregar test inicial de RegistroProcesamiento

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "pydantic>=2.6.0",
     "pydantic-settings>=2.2.0",
     "pymongo>=4.6.0",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/domain/entities/documento_pdf.py
+++ b/src/domain/entities/documento_pdf.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from src.domain.entities.base_entity import BaseEntity
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DocumentoPDF(BaseEntity):
     """
     Representa un documento PDF validado en el sistema.

--- a/src/domain/entities/registro_procesamiento.py
+++ b/src/domain/entities/registro_procesamiento.py
@@ -12,7 +12,7 @@ from uuid import UUID, uuid4
 from src.domain.entities.base_entity import BaseEntity
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RegistroProcesamiento(BaseEntity):
     """
     Representa un registro histórico de procesamiento de PDF.

--- a/tests/domain/test_entities/test_registro_procesamiento.py
+++ b/tests/domain/test_entities/test_registro_procesamiento.py
@@ -1,0 +1,16 @@
+from src.domain.entities.registro_procesamiento import RegistroProcesamiento
+
+def test_registro_procesamiento_se_crea_con_campos_obligatorios():
+    nombre_prueba = "apuntes_universidad.pdf"
+    texto_prueba = "Este es el contenido extraído."
+
+    registro = RegistroProcesamiento(
+        nombre_archivo_original=nombre_prueba,
+        contenido_extraido=texto_prueba
+    )
+
+    assert registro.nombre_archivo_original == nombre_prueba
+    assert registro.contenido_extraido == texto_prueba
+    assert registro.id is not None
+    assert registro.created_at is not None
+    assert registro.updated_at is not None


### PR DESCRIPTION
Agregue a las entidades kw_only, para que cuando instancien un PDF o un Registro en sus tests, tengan que pasarle los parámetros por nombre (ej: nombre_archivo='x').
Realice el test inicial de RegistroProcesamiento