### PR TITLE
fix(domain): corregir herencia en DTO's y agregar test inicial de TextoExtraidoDTO

### DIFF
--- a/src/application/dtos/pdf_dtos.py
+++ b/src/application/dtos/pdf_dtos.py
@@ -41,7 +41,7 @@ class ArchivoEntradaDTO(BaseInputDTO):
 
 
 @dataclass(frozen=True)
-class TextoExtraidoDTO(BaseOutputDTO):
+class TextoExtraidoDTO():
     """
     DTO para transportar el texto extraído de un PDF.
 
@@ -65,7 +65,7 @@ class TextoExtraidoDTO(BaseOutputDTO):
 
 
 @dataclass(frozen=True)
-class ArchivoSalidaDTO(BaseOutputDTO):
+class ArchivoSalidaDTO():
     """
     DTO para entregar un archivo generado a la capa de interface.
 

--- a/tests/application/test_dtos/test_pdf_dtos.py
+++ b/tests/application/test_dtos/test_pdf_dtos.py
@@ -1,0 +1,10 @@
+import pytest
+from src.application.dtos.pdf_dtos import TextoExtraidoDTO
+
+def test_texto_extraido_dto_es_inmutable():
+    dto = TextoExtraidoDTO(contenido="Texto original del PDF", cantidad_caracteres=30, cantidad_palabras=5)
+
+    with pytest.raises(Exception) as error_info:
+        dto.contenido = "Texto modificado maliciosamente"
+
+    print(f"\nEl error capturado fue: {error_info.type}")


### PR DESCRIPTION
Corregi unas herencias mal colocadas en TextoExtraidoDTO y ArchivoSalidaDTO.
Agregue el test inicial de TextoExtraidoDTO